### PR TITLE
Work with STDIN by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ return [
 
 The configuration file supports one or more environments. An environment requires a minimum of two keys:
 
-- `yamlFile` - the path to the YAML file, relative to root of your Yami install.
+- `yamlFile` - the path to the YAML file, relative to root of your Yami install. Use `php://stdin` to read file from STDIN (output will be sent to STDOUT).
 - `path` - the path to the `migrations` directory, relative to root of your Yami install.
 
 Further configuration options are outlined below.
@@ -202,7 +202,13 @@ To test the migrations without overriding the YAML file, run `vendor/bin/yami mi
 
 To commit and save the migration, run `vendor/bin/yami migrate`.
 
-Caution: If you don't specify an environment using the `--env=<environment>` or `-e <environment>` parameter, the default environment will be used which may not be what is expected.
+Caution: If you don't specify an environment using the `--env=<environment>` or `-e <environment>` parameter, the default environment will be used which may not be what is expected. Default environment name is `-` and it is configured to use STDIN as YAML file and `./migration` as migrations dir.
+
+  **Options:**
+ * `-p <path>` -- override path set in  config
+ * `-h` -- do not update history
+
+> **Notice:** Migration process is transactional. So if any migration failed no changes won't be applied.
 
 ## Rolling Back
 

--- a/src/Yami/Config/Bootstrap.php
+++ b/src/Yami/Config/Bootstrap.php
@@ -3,7 +3,6 @@
 namespace Yami\Config;
 
 use Console\Args;
-use DateTime;
 
 class Bootstrap
 {
@@ -40,6 +39,10 @@ class Bootstrap
             'nullAsTilde'           => false,
         ],
         'environments' => [
+            '-' => [
+                'yamlFile'  => 'php://stdin',
+                'path'      => './migrations'
+            ]
         ],
     ];
 
@@ -103,7 +106,7 @@ class Bootstrap
         $environment = static::validateEnvArgument($config, $args);
 
         $originalYaml = static::$config->environments->$environment->yamlFile;
-        $mockFilename = preg_replace('/.(yml|yaml)/', '_' . (new DateTime())->format('YmdHis') . '.mock.$1', $originalYaml);
+        $mockFilename = tempnam(sys_get_temp_dir(),'yami.mock');
 
         file_put_contents($mockFilename, $yaml ?? trim(file_get_contents($originalYaml)));
 
@@ -138,6 +141,10 @@ class Bootstrap
     {
         $config = static::getConfig($args);
         $environment = static::validateEnvArgument($config, $args);
+
+        if (isset($args->{'path'})) {
+            $config->environments->$environment->path = $args->{'path'};
+        }
 
         $config->environments->$environment->name = $environment;
 

--- a/src/Yami/Console/Config.php
+++ b/src/Yami/Console/Config.php
@@ -2,7 +2,7 @@
 
 namespace Yami\Console;
 
-use Console\{CommandInterface, Args, StdOut};
+use Console\{CommandInterface, Args };
 
 class Config implements CommandInterface
 {
@@ -16,13 +16,13 @@ class Config implements CommandInterface
         ]);
 
         if (isset($args->{'no-ansi'})) {
-            StdOut::disableAnsi();
+            MessageStream::disableAnsi();
         }
 
         $configFile = $args->project ? './' . preg_replace('/[^\w]/', '_', strtolower($args->project)) . '.php' : './config.php';
 
         if (file_exists($configFile)) {
-            StdOut::write([
+            MessageStream::write([
                 [sprintf("Config file %s already exists.\n\n", $configFile), 'red']
             ]);
             exit(1);
@@ -31,11 +31,11 @@ class Config implements CommandInterface
         file_put_contents($configFile, file_get_contents(__DIR__ . '/templates/config.template'));
 
         if ($args->path) {
-            StdOut::write([
+            MessageStream::write([
                 [sprintf("Created config file %s at path \"%s\".\n\n", $configFile, $args->path), 'white']
             ]);
         } else {
-            StdOut::write([
+            MessageStream::write([
                 [sprintf("Created config file %s.\n\n", $configFile), 'white']
             ]);
         }

--- a/src/Yami/Console/Create.php
+++ b/src/Yami/Console/Create.php
@@ -2,7 +2,7 @@
 
 namespace Yami\Console;
 
-use Console\{CommandInterface, Args, StdOut};
+use Console\{CommandInterface, Args };
 use Yami\Config\Bootstrap;
 use DateTime;
 
@@ -19,11 +19,11 @@ class Create implements CommandInterface
         ]);
 
         if (isset($args->{'no-ansi'})) {
-            StdOut::disableAnsi();
+            MessageStream::disableAnsi();
         }
 
         if (!$args->migration) {
-            StdOut::write([
+            MessageStream::write([
                 [sprintf("Migration name not supplied. Please use parameter --migration=NameOfMigration or -m NameOfMigration.\n\n"), 'red']
             ]);
             exit(1);
@@ -32,7 +32,7 @@ class Create implements CommandInterface
         $args->migration = preg_replace('/[^A-Za-z0-9]/', '', $args->migration);
 
         if (!preg_match('/^[A-Z]{1,}[A-Za-z0-9]+/', $args->migration)) {
-            StdOut::write([
+            MessageStream::write([
                 [sprintf("Migration name is not valid. Please use CamelCase with letters and numbers only. The first character must be a capital letter.\n\n"), 'red']
             ]);
             exit(1);
@@ -46,7 +46,7 @@ class Create implements CommandInterface
 
         file_put_contents($environment->path . '/' . $filename . '.php', str_replace('{{ClassName}}', $args->migration, file_get_contents(__DIR__ . '/templates/migration.template')));
 
-        StdOut::write([
+        MessageStream::write([
             [sprintf("Created %s\n\n", $environment->path . '/' . $filename . '.php'), 'white']
         ]);
     }

--- a/src/Yami/Console/History.php
+++ b/src/Yami/Console/History.php
@@ -3,7 +3,7 @@
 namespace Yami\Console;
 
 use Yami\Console\Traits\HistoryTrait;
-use Console\{CommandInterface, Args, StdOut};
+use Console\{CommandInterface, Args };
 use Yami\Config\Bootstrap;
 use DateTime;
 
@@ -41,7 +41,7 @@ class History implements CommandInterface
         ]);
 
         if (isset($args->{'no-ansi'})) {
-            StdOut::disableAnsi();
+            MessageStream::disableAnsi();
         }
 
         $this->args = $args;
@@ -50,39 +50,39 @@ class History implements CommandInterface
 
         $this->loadHistory(true);
 
-        StdOut::write([
+        MessageStream::write([
             [sprintf('Using configuration: '), 'white'], 
             [sprintf("%s\n", $this->args->config ? $this->args->config : './config.php'), 'light_blue']
         ]);
         if ($this->environment->name != $this->args->env) {
-            StdOut::write([
+            MessageStream::write([
                 [sprintf("Warning, no environment specified; defaulting to '%s'\n", $this->environment->name), 'light_red']
             ]);
         } else {
-            StdOut::write([
+            MessageStream::write([
                 [sprintf('Using environment: '), 'white'], 
                 [sprintf("%s\n", $this->environment->name), 'light_blue']
             ]);
         }
 
-        StdOut::write([
+        MessageStream::write([
             [sprintf("\nDate                | Batch ID | Migration \n"), 'white'], 
             [sprintf("-----------------------------------------------------------------------------------\n"), 'white'], 
         ]);
 
         foreach(array_reverse($this->history) as $history) {
-            StdOut::write([
+            MessageStream::write([
                 [sprintf("%s | %s | %s \n", DateTime::createFromFormat('U', $history->ts)->format('Y-m-d H:i:s'), str_pad($history->batchId, 8), substr($history->migration, 0, 50)), 'white'], 
             ]);
         }
 
         if (!count($this->history)) {
-            StdOut::write([
+            MessageStream::write([
                 [sprintf("No migrations found.\n"), 'white']
             ]);    
         }
 
-        StdOut::write([
+        MessageStream::write([
             [sprintf("\n"), 'grey']
         ]);
 

--- a/src/Yami/Console/Mask.php
+++ b/src/Yami/Console/Mask.php
@@ -17,12 +17,7 @@ class Mask implements CommandInterface
             'c' => 'config',
             'd' => 'dry-run',
             'e' => 'env',
-            'n' => 'no-ansi'
         ]);
-
-        if (isset($args->{'no-ansi'})) {
-            StdOut::disableAnsi();
-        }
 
         $config = Bootstrap::getConfig($args);
         $environment = Bootstrap::getEnvironment($args);
@@ -41,12 +36,16 @@ class Mask implements CommandInterface
         if ($isDryRun) {
             echo $yaml . "\n";
         } else {
-            $backupFile = preg_replace('/.(yml|yaml)/', '_' . (new DateTime())->format('YmdHis') . '.$1', $yamlFile);
-            file_put_contents($backupFile, trim(file_get_contents($yamlFile)));
-            file_put_contents($yamlFile, $yaml);
-            StdOut::write([
-                [sprintf("Masked %s. The original has been backed up as %s.\n\n", $yamlFile, $backupFile), 'white']
-            ]);
+            if ($yamlFile === 'php://stdin') {
+                file_put_contents('php://stdout', $yaml);
+            } else {
+                $backupFile = preg_replace('/.(yml|yaml)/', '_' . (new DateTime())->format('YmdHis') . '.$1', $yamlFile);                
+                file_put_contents($backupFile, trim(file_get_contents($yamlFile)));
+                file_put_contents($yamlFile, $yaml);
+                MessageStream::write([
+                    [sprintf("Masked %s. The original has been backed up as %s.\n\n", $yamlFile, $backupFile), 'white']
+                ]);    
+            }
         }
 
     }

--- a/src/Yami/Console/Migrate.php
+++ b/src/Yami/Console/Migrate.php
@@ -28,10 +28,10 @@ class Migrate extends AbstractConsole
 
             // Extract version
             preg_match('/[0-9]{4}_[0-9]{2}_[0-9]{2}_[0-9]{6}/', $uniqueId, $matches);
-            if ($matches[0]) {
+            if ($matches && $matches[0]) {
                 $version = $matches[0];
             } else {
-                throw new \Exception("Unable to parse version from migration.");
+                throw new \Exception("Unable to parse version from migration $uniqueId");
             }
 
             $className = preg_replace_callback('/(_[a-z_])/', function($m) {
@@ -60,26 +60,20 @@ class Migrate extends AbstractConsole
      * 
      * @return string
      */
-    protected function getMessages(int $batchNo): string
+    protected function getMessages(int $batchNo): array
     {
-        $messages = '';
+        $messages = [];
 
         if (isset($this->environment->secretsManager) && isset($this->environment->secretsManager->adapter)) {
-            $messages .= StdOut::format([
-                [sprintf('Using secrets manager: '), 'white'], 
-                [sprintf("%s\n", $this->environment->secretsManager->adapter), 'light_blue']
-            ]);
+            $messages[] = [sprintf('Using secrets manager: '), 'white'];
+            $messages[] = [sprintf("%s\n", $this->environment->secretsManager->adapter), 'light_blue'];
         }
 
-        $messages .= StdOut::format([
-            [sprintf('Batch id: '), 'white'], 
-            [sprintf("%d\n", $batchNo + 1), 'light_blue']
-        ]);
+        $messages[] = [sprintf('Batch id: '), 'white'];
+        $messages[] = [sprintf("%d\n", $batchNo + 1), 'light_blue'];
 
         if (isset($this->args->{'dry-run'})) {
-            $messages .= StdOut::format([
-                [sprintf("\nStarting dry run...\n"), 'yellow'], 
-            ]);
+            $messages[] = [sprintf("\nStarting dry run...\n"), 'yellow'];
         }
 
         return $messages;

--- a/src/Yami/Migration/AbstractMigration.php
+++ b/src/Yami/Migration/AbstractMigration.php
@@ -39,13 +39,13 @@ abstract class AbstractMigration
      */
     protected $activeNode;
 
-    public function __construct(string $action, \stdClass $migration, Args $args)
+    public function __construct(string $action, array $yaml, \stdClass $migration, Args $args)
     {
         $this->args = $args;
         $this->config = Bootstrap::getConfig($args);
         $this->environment = Bootstrap::getEnvironment($args);
 
-        $this->yaml = Adapter::load($this->config, $this->environment);
+        $this->yaml = $yaml;
 
         switch ($action) {
             case self::ACTION_MIGRATE:
@@ -103,13 +103,13 @@ abstract class AbstractMigration
     }
 
     /**
-     * Write out the YAML file
+     * Return processed YAML
      */
-    public function save(): void
+    public function save(): array
     {
         $this->syncNode();
 
-        Adapter::save($this->yaml, $this->config, $this->environment);
+        return $this->yaml;
     }
 
     /**

--- a/src/Yami/Secrets/Adapters/SSM.php
+++ b/src/Yami/Secrets/Adapters/SSM.php
@@ -56,8 +56,9 @@ class SSM implements SecretsManagerInterface
                 'WithDecryption' => true
             ]);
         } catch (SsmException $e) {
-            $response = json_decode((string) $e->getResponse()->getBody());
-            if ($response->__type == 'ParameterNotFound') {
+            $resp = $e->getResponse(); // is null on network error
+            $response = $resp && json_decode((string) $resp->getBody());
+            if ($response && $response->__type == 'ParameterNotFound') {
                 throw new \Exception(sprintf("Parameter \"%s\" not found in SSM. Also tried looking for environment variable \"%s\".", $key, Utils::keyToEnv($key)));
             } else {
                 throw new \Exception(sprintf("Error accessing parameter \"%s\" in SSM. Also tried looking for environment variable \"%s\".\n%s", $key, Utils::keyToEnv($key), $e));

--- a/yami
+++ b/yami
@@ -3,8 +3,6 @@
 
 include_once("vendor/autoload.php");
 
-echo "-------------------------\n";
-
 $console = new Console\Runner();
 $console->setAppName('Yami');
 $console->setAppVersion('0.0.1');
@@ -42,23 +40,25 @@ $args = new Console\Args($argv);
 $args->setAliases([
     'n' => 'no-ansi'
 ]);
-if (isset($args->{'no-ansi'})) {
-    Console\StdOut::disableAnsi();
-}
+
+// disable ANSI automatically if output is not a terminal (i.e. redirected to file)
+// XXX: made a default logic of isAnsiEnabled() ?
+if (isset($args->{'no-ansi'}) || !posix_isatty(STDOUT)) Console\StdOut::disableAnsi();
+if (isset($args->{'no-ansi'}) || !posix_isatty(STDERR)) Console\StdErr::disableAnsi();
 
 // Start your engines...
 try {
     $console->run();
 } catch(Console\Exception\CommandNotFoundException $e) {
-    echo $console->getHelp();
+    Console\StdErr::write([[ $console->getHelp(), 'red' ]]);
     exit(1);
 } catch(Exception $e) {
-    Console\StdOut::write([
+    Console\StdErr::write([
         [sprintf("%s\n\n", $e->getMessage()), 'red bold']
     ]);
     exit(1);
 } catch(Throwable $t) {
-    Console\StdOut::write([
+    Console\StdErr::write([
         [sprintf("%s\n\n", $t), 'red bold']
     ]);
     exit(1);


### PR DESCRIPTION
Status/error messages printed to STDERR like most system tools are doing. So it's possible to process YAML from STDIN to STDOUT while still seeing messages in console (or send them to separate log). Example:
`yaml migrate -c projects/www/config.php < credentials.yml > processed.yml 2>migration.log`

When stdout or stderr is redirected to file `no-ansi` is enabled automatically.

Other changes:
 - all operations performed in memory before writing result file. As a result migration/rollback process is now transactional - if any migration fails no changes will be saved
 - new options:
    `-p` - override path set in config
    `-h` - disable history update (history doesn't make sense for operations with stdin)

Requires Console with https://github.com/shaggy8871/console/pull/2 merged 